### PR TITLE
EPMRPP-107161 || Add payment-related error types

### DIFF
--- a/src/main/java/com/epam/reportportal/rules/exception/ErrorType.java
+++ b/src/main/java/com/epam/reportportal/rules/exception/ErrorType.java
@@ -52,6 +52,16 @@ public enum ErrorType {
   UPSA_USER_DENIED(4005, "Unable to assign/unassign user to/from project. Please verify user assignment to the organization in EPAM internal system: delivery.epam.com"),
 
   /**
+   * If operation requires payment
+   */
+  PAYMENT_REQUIRED(4020, "Payment Required. {}"),
+
+  /**
+   * If operation requires a paid plugin
+   */
+  PAID_PLUGIN_REQUIRED(4021, "Plugin '{}' is required. {}"),
+
+  /**
    * If specified by id Project or by ProjectName not found
    */
   PROJECT_NOT_FOUND(4040, "Project '{}' not found. Did you use correct project name?"),


### PR DESCRIPTION
This pull request adds new error types to the `ErrorType` enum to support payment-related operations. These additions help the system handle scenarios where payment or paid plugins are required for certain actions.

New payment-related error types:

* Added `PAYMENT_REQUIRED` (code 4020) for operations that require payment.
* Added `PAID_PLUGIN_REQUIRED` (code 4021) for operations that require a paid plugin.